### PR TITLE
Added ytmusic argument to get_yt_playlist_content() method

### DIFF
--- a/src/ytfuncs.py
+++ b/src/ytfuncs.py
@@ -62,7 +62,7 @@ def yt_dest_check(ytmusic, yt_lists, dest_playlist_name):
 
 def move_to_ytmusic(ytmusic, playlist_info, dest_id):
    not_found = []
-   present_song = get_yt_playlist_content(dest_id)
+   present_song = get_yt_playlist_content(ytmusic, dest_id)
    playlist_info = what_to_move(present_song, playlist_info)
    not_found = []
    try:


### PR DESCRIPTION
Hi @Lytes.
The ```get_yt_playlist_content``` method was previously called without the ytmusic argument in the ```move_to_ytmusic``` function. I realized when i tried to move my music from apple to youtube and it was crashing all the time with this exception: ```AttributeError: 'str' object has no attribute 'get_playlist'```

The code has been corrected to include the necessary argument when calling get_yt_playlist_content within move_to_ytmusic. This ensures that the correct playlist's content is fetched and processed.